### PR TITLE
Build: remove build breaking file

### DIFF
--- a/http-server-netty/src/test/resources/public/测试-0.0.yml
+++ b/http-server-netty/src/test/resources/public/测试-0.0.yml
@@ -1,4 +1,0 @@
-openapi: 3.0.1
-info:
-  title: 测试
-  version: "0.0"


### PR DESCRIPTION
The file i removed prevented gradle from running on my machine with the message "FileNotFoundException: ?????-0.0.yml" so it seems not to work in all environments making the build less reproduceable.

The file seemed to have no important contend - tests still passed for me (`./gradlew check`) and the file wasn't touched for years